### PR TITLE
Feature/reset password fix

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.dyne/just-auth "0.5.0-SNAPSHOT"
+(defproject org.clojars.dyne/just-auth "0.6.0-SNAPSHOT"
   :description "Simple two factor authentication library"
   :url "https://github.com/PIENews/just-auth"
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.dyne/just-auth "0.6.0-SNAPSHOT"
+(defproject org.clojars.dyne/just-auth "0.6.0"
   :description "Simple two factor authentication library"
   :url "https://github.com/PIENews/just-auth"
 

--- a/src/just_auth/core.clj
+++ b/src/just_auth/core.clj
@@ -62,7 +62,7 @@
 
   (de-activate-account [this email password])
 
-  (reset-password [this email old-password new-password second-step-conf])
+  (reset-password [this email new-password second-step-conf])
 
   (list-accounts [this params]))
 
@@ -184,12 +184,9 @@
     ;; TODO
     )
 
-  (reset-password [_ email old-password new-password {:keys [password-reset-link]}]
+  (reset-password [_ email new-password {:keys [password-reset-link]}]
     (if (= (pr/fetch-by-password-recovery-link password-recovery-store password-reset-link))
-      (if (account/correct-password? account-store email old-password (:hash-check-fn hash-fns))
-        (account/update-password! account-store email new-password (:hash-fn hash-fns))
-        ;; TODO: send email?
-        (f/fail (t/locale [:error :core :wrong-pass])))
+      (account/update-password! account-store email new-password (:hash-fn hash-fns)) 
       (f/fail (t/locale [:error :core :expired-link]))))
 
   (list-accounts [_ params]


### PR DESCRIPTION
These changes come from @ivanminutillo and agreed with @jaromil - closed previous PR due to ident changes https://github.com/Commonfare-net/just-auth/pull/35

I propose to split the current reset-password logic in 2 separate functions:

reset-password:
(reset-password [this email new-password second-step-conf])
The reset-password function is meant to be used if the user lost the current password and is not able to log-in anymore. This method will allow to set a new password if a token is provided.

replace-password
(replace-password [this email old-password new-password])
The replace-password is meant to be used if the user still has the current password but wants to replace it with a new one.

This pull-request implements only the reset-password method, leaving the other open to discussion, mostly because reset-password is the function I need to showcase a whole user flow of the social-wallet app

ps. we're dealing with indentation issue, we're working on it for future pull-requests